### PR TITLE
Update layout.conf for future compatibility

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -2,3 +2,4 @@ thin-manifests = true
 sign-manifests = false
 profile-formats = portage-2
 cache-formats = md5-dict
+masters = gentoo


### PR DESCRIPTION
You can see the change in the comment by dol-sen here:
https://forums.gentoo.org/viewtopic-t-969480-start-0.html
Portage requires a layout.conf file with masters attribute set.